### PR TITLE
Feat: /list, /save api간 데이터 전달을 위한 속성 추가, 미선택 Repo 리스트 조회

### DIFF
--- a/src/main/java/org/example/controller/ApiController.java
+++ b/src/main/java/org/example/controller/ApiController.java
@@ -4,8 +4,10 @@ import org.example.dto.RepositoryResponseDto;
 import org.example.dto.RepositorySaveRequestDto;
 import org.example.dto.RepositoryUpdateRequestDto;
 import org.example.dto.SingleRepositoryResponseDto;
+import org.example.entity.ManagedRepo;
 import org.example.service.GitHubService;
 import org.example.service.RepoService;
+import org.example.service.UnselectedRepoService;
 import org.example.utils.JwtUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,10 +21,12 @@ public class ApiController {
 
     private final RepoService repoService;
     private final GitHubService gitHubService;
+    private final UnselectedRepoService unselectedRepoService;
 
-    public ApiController(RepoService repoService, GitHubService gitHubService) {
+    public ApiController(RepoService repoService, GitHubService gitHubService, UnselectedRepoService unselectedRepoService) {
         this.repoService = repoService;
         this.gitHubService = gitHubService;
+        this.unselectedRepoService = unselectedRepoService;
     }
 
     // 1) 사용자 GitHub Repository 목록 가져오기
@@ -81,6 +85,18 @@ public class ApiController {
     public ResponseEntity<String> deleteRepository(@PathVariable Long id) {
         repoService.deleteRepository(id);
         return ResponseEntity.noContent().build();
+    }
+
+    // 7) DB에 저장된 레포 제외 선택되지 않은 레포 리스트 조회
+    @GetMapping("/unselected")
+    public ResponseEntity<List<Map<String, Object>>> getUnselectedRepositories() {
+        String username = JwtUtil.getUsernameFromContext();
+        if (username == null) {
+            throw new RuntimeException("사용자 이름이 없습니다.");
+        }
+
+        List<Map<String, Object>> unselectedRepositories = unselectedRepoService.getUnselectedRepositories(username);
+        return ResponseEntity.ok(unselectedRepositories);
     }
 
 }

--- a/src/main/java/org/example/repository/RepoRepository.java
+++ b/src/main/java/org/example/repository/RepoRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface RepoRepository extends JpaRepository<ManagedRepo, Long> {
     List<ManagedRepo> findByUsername(String username);
+    // ProjectType 미선택인 레포지토리 조회를 위한 추가
+    List<ManagedRepo> findByProjectType(ManagedRepo.ProjectType projectType);
 }

--- a/src/main/java/org/example/service/GitHubService.java
+++ b/src/main/java/org/example/service/GitHubService.java
@@ -61,6 +61,12 @@ public class GitHubService {
         result.put("name", ownerLogin + "/" + repoName);
         result.put("owner", ownerLogin);
         result.put("repo_name", repoName);
+        // '/list', '/save' api간 데이터 전달을 위한 추가
+        result.put("htmlUrl", repo.get("html_url")); // 저장소 URL
+        result.put("description", repo.get("description")); // 설명
+        result.put("createdAt", repo.get("created_at")); // 생성 날짜
+        result.put("updatedAt", repo.get("updated_at")); // 업데이트 날짜
+        result.put("pushedAt", repo.get("pushed_at")); // 마지막 푸시 날짜
         return result;
     }
 

--- a/src/main/java/org/example/service/UnselectedRepoService.java
+++ b/src/main/java/org/example/service/UnselectedRepoService.java
@@ -1,0 +1,38 @@
+package org.example.service;
+
+import org.example.entity.ManagedRepo;
+import org.example.repository.RepoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class UnselectedRepoService {
+
+    private final RepoRepository repoRepository;
+    private final GitHubService gitHubService;
+
+    public UnselectedRepoService(RepoRepository repoRepository, GitHubService gitHubService) {
+        this.repoRepository = repoRepository;
+        this.gitHubService = gitHubService;
+    }
+
+    public List<Map<String, Object>> getUnselectedRepositories(String username) {
+        // 1. GitHub에서 모든 레포지토리 가져오기
+        List<Map<String, Object>> allReposFromGitHub = gitHubService.fetchUserRepositories(username);
+
+        // 2. DB에서 저장된(선택된) 레포지토리 이름 조회
+        Set<String> selectedRepoNames = repoRepository.findByUsername(username).stream()
+                .map(ManagedRepo::getRepository_name)
+                .collect(Collectors.toSet());
+
+        // 3. GitHub 데이터 중 DB에 없는 레포지토리 필터링
+        return allReposFromGitHub.stream()
+                .filter(repo -> !selectedRepoNames.contains(repo.get("name"))) // DB에 없는 레포만 필터링
+                .toList();
+    }
+
+}


### PR DESCRIPTION
- 기존 '/list', 'save' api 간 넘겨주는 데이터 속성값이 존재하지 않는 문제 해결을 위한, GithubService 수정 (속성값 추가 전달)
- 프로젝트 추가하기 기능에서 기존에 선택되지 않은(DB에 저장되어있지 않은) Repository 리스트 조회를 위한 서비스 구현
   (UnselectedRepoService 추가 및 ApiController 7번 기능 추가)